### PR TITLE
Reformat using black

### DIFF
--- a/demos/contact_immobile_racket.py
+++ b/demos/contact_immobile_racket.py
@@ -8,13 +8,13 @@ import multiprocessing
 
 mujoco_id = "mj"
 model_name = "contacts"
-items = pam_mujoco.model_factory("contacts",table=True,robot1=True)
+items = pam_mujoco.model_factory("contacts", table=True, robot1=True)
 ball = items["ball"]
 table = items["table"]
 robot = items["robot"]
 
 # running mujoco thread
-def execute_mujoco(ball,table,robot,mujoco_id,model_name):
+def execute_mujoco(ball, table, robot, mujoco_id, model_name):
     # init mujoco
     config = pam_mujoco.MujocoConfig()
     config.graphics = True
@@ -25,37 +25,42 @@ def execute_mujoco(ball,table,robot,mujoco_id,model_name):
     # note: best to add first (i.e. before mirror robot and
     # mirror ball), as controllers are called in sequence,
     # and contact info will change behavior of mirror ball controller
-    pam_mujoco.add_robot1_contact_free_joint("racket",
-                                             ball.index_qpos,ball.index_qvel,
-                                             ball.geom,robot.geom_racket)
+    pam_mujoco.add_robot1_contact_free_joint(
+        "racket", ball.index_qpos, ball.index_qvel, ball.geom, robot.geom_racket
+    )
     # for detecting contact with the table
-    pam_mujoco.add_table_contact_free_joint("table",
-                                            ball.index_qpos,ball.index_qvel,
-                                            ball.geom,table.geom_plate)
+    pam_mujoco.add_table_contact_free_joint(
+        "table", ball.index_qpos, ball.index_qvel, ball.geom, table.geom_plate
+    )
     # adding the mirror ball controller
     # (mirroring will be interrupted upon contact with the racket:
     # the contact controller (added right above) will write contact information
-    # in the shared memory (segment: segment_id_contacts). The ball mirroring 
+    # in the shared memory (segment: segment_id_contacts). The ball mirroring
     # controller will stop mirroring the ball after the data shared in the memory
     # shows a contact occured).
-    pam_mujoco.add_mirror_until_contact_free_joint("ball",
-                                                   ball.joint,
-                                                   ball.index_qpos,ball.index_qvel,
-                                                   "racket")
+    pam_mujoco.add_mirror_until_contact_free_joint(
+        "ball", ball.joint, ball.index_qpos, ball.index_qvel, "racket"
+    )
     # adding robot mirroring controller
-    pam_mujoco.add_mirror_robot("robot",
-                                robot.joint)
+    pam_mujoco.add_mirror_robot("robot", robot.joint)
     # starting the thread
-    pam_mujoco.execute(mujoco_id,model_name)
+    pam_mujoco.execute(mujoco_id, model_name)
     # looping until requested to stop
     while not pam_mujoco.is_stop_requested(mujoco_id):
         time.sleep(0.01)
 
 
 # starting mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(ball,table,robot,
-                                         mujoco_id,model_name,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        ball,
+        table,
+        robot,
+        mujoco_id,
+        model_name,
+    ),
+)
 pam_mujoco.clear(mujoco_id)
 process.start()
 pam_mujoco.wait_for_mujoco(mujoco_id)
@@ -73,38 +78,37 @@ ball_x = 0.94
 ball_y = 0.45
 ball_z_start = 1.0
 ball_z_end = -3.0
-start_point = [ball_x,ball_y,ball_z_start]
-end_point = [ball_x,ball_y,ball_z_end]
-duration = 5.0 # seconds
-velocity = [0,0,(end_point[2]-start_point[2])/duration]
+start_point = [ball_x, ball_y, ball_z_start]
+end_point = [ball_x, ball_y, ball_z_end]
+duration = 5.0  # seconds
+velocity = [0, 0, (end_point[2] - start_point[2]) / duration]
 # "teleportation" to start point
 for dim in range(3):
-    frontend_ball.add_command(2*dim,
-                         o80.State1d(start_point[dim]),
-                         o80.Mode.QUEUE)
+    frontend_ball.add_command(2 * dim, o80.State1d(start_point[dim]), o80.Mode.QUEUE)
 # falling down to end point
 for dim in range(3):
-    frontend_ball.add_command(2*dim,
-                         o80.State1d(end_point[dim]),
-                         o80.Duration_us.seconds(int(duration)),
-                         o80.Mode.QUEUE)
-    frontend_ball.add_command(2*dim+1,
-                         o80.State1d(velocity[dim]),
-                         o80.Duration_us.seconds(int(duration)),
-                         o80.Mode.QUEUE)
+    frontend_ball.add_command(
+        2 * dim,
+        o80.State1d(end_point[dim]),
+        o80.Duration_us.seconds(int(duration)),
+        o80.Mode.QUEUE,
+    )
+    frontend_ball.add_command(
+        2 * dim + 1,
+        o80.State1d(velocity[dim]),
+        o80.Duration_us.seconds(int(duration)),
+        o80.Mode.QUEUE,
+    )
 
 
 # having the robot going to a reference position
-robot_target = [np.pi/4.0,
-                np.pi/3.5,
-                np.pi/3.0,
-                np.pi/4.0]
-robot_target = [o80.State2d(rt,0) for rt in robot_target]
-for dof,target in enumerate(robot_target):
-    frontend_robot.add_command(dof,target,
-                               o80.Duration_us.milliseconds(500),
-                               o80.Mode.QUEUE)
-    
+robot_target = [np.pi / 4.0, np.pi / 3.5, np.pi / 3.0, np.pi / 4.0]
+robot_target = [o80.State2d(rt, 0) for rt in robot_target]
+for dof, target in enumerate(robot_target):
+    frontend_robot.add_command(
+        dof, target, o80.Duration_us.milliseconds(500), o80.Mode.QUEUE
+    )
+
 # sending ball trajectory and robot motion
 frontend_ball.pulse_prepare_wait()
 frontend_robot.pulse_prepare_wait()
@@ -119,19 +123,18 @@ time.sleep(1)
 time_start = time.time()
 first_contact_racket = False
 first_contact_table = False
-while time.time()-time_start < duration:
+while time.time() - time_start < duration:
     contacts_racket = pam_mujoco.get_contact("racket")
     if contacts_racket.contact_occured and not first_contact_racket:
         print("-- contact with racket")
-        first_contact_racket=True;
+        first_contact_racket = True
     contacts_table = pam_mujoco.get_contact("table")
     if contacts_table.contact_occured and not first_contact_table:
         print("-- contact with table")
-        print("\tposition:",",".join([str(a) for a in contacts_table.position]))
-        first_contact_table=True;
+        print("\tposition:", ",".join([str(a) for a in contacts_table.position]))
+        first_contact_table = True
     time.sleep(0.1)
-    
+
 # stopping the mujoco thread
 pam_mujoco.request_stop("mj")
 process.join()
-

--- a/demos/contact_moving_racket.py
+++ b/demos/contact_moving_racket.py
@@ -8,13 +8,13 @@ import multiprocessing
 
 mujoco_id = "mj"
 model_name = "contacts"
-items = pam_mujoco.model_factory("contacts",table=True,robot1=True)
+items = pam_mujoco.model_factory("contacts", table=True, robot1=True)
 ball = items["ball"]
 table = items["table"]
 robot = items["robot"]
 
 # running mujoco thread
-def execute_mujoco(ball,table,robot,mujoco_id,model_name):
+def execute_mujoco(ball, table, robot, mujoco_id, model_name):
     # init mujoco
     config = pam_mujoco.MujocoConfig()
     config.graphics = True
@@ -25,37 +25,42 @@ def execute_mujoco(ball,table,robot,mujoco_id,model_name):
     # note: best to add first (i.e. before mirror robot and
     # mirror ball), as controllers are called in sequence,
     # and contact info will change behavior of mirror ball controller
-    pam_mujoco.add_robot1_contact_free_joint("racket",
-                                             ball.index_qpos,ball.index_qvel,
-                                             ball.geom,robot.geom_racket)
+    pam_mujoco.add_robot1_contact_free_joint(
+        "racket", ball.index_qpos, ball.index_qvel, ball.geom, robot.geom_racket
+    )
     # for detecting contact with the table
-    pam_mujoco.add_table_contact_free_joint("table",
-                                      ball.index_qpos,ball.index_qvel,
-                                      ball.geom,table.geom_plate)
+    pam_mujoco.add_table_contact_free_joint(
+        "table", ball.index_qpos, ball.index_qvel, ball.geom, table.geom_plate
+    )
     # adding the mirror ball controller
     # (mirroring will be interrupted upon contact with the racket:
     # the contact controller (added right above) will write contact information
-    # in the shared memory (segment: segment_id_contacts). The ball mirroring 
+    # in the shared memory (segment: segment_id_contacts). The ball mirroring
     # controller will stop mirroring the ball after the data shared in the memory
     # shows a contact occured).
-    pam_mujoco.add_mirror_until_contact_free_joint("ball",
-                                                   ball.joint,
-                                                   ball.index_qpos,ball.index_qvel,
-                                                   "racket")
+    pam_mujoco.add_mirror_until_contact_free_joint(
+        "ball", ball.joint, ball.index_qpos, ball.index_qvel, "racket"
+    )
     # adding robot mirroring controller
-    pam_mujoco.add_mirror_robot("robot",
-                                robot.joint)
+    pam_mujoco.add_mirror_robot("robot", robot.joint)
     # starting the thread
-    pam_mujoco.execute(mujoco_id,model_name)
+    pam_mujoco.execute(mujoco_id, model_name)
     # looping until requested to stop
     while not pam_mujoco.is_stop_requested(mujoco_id):
         time.sleep(0.01)
 
 
 # starting mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(ball,table,robot,
-                                         mujoco_id,model_name,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        ball,
+        table,
+        robot,
+        mujoco_id,
+        model_name,
+    ),
+)
 pam_mujoco.clear(mujoco_id)
 process.start()
 pam_mujoco.wait_for_mujoco(mujoco_id)
@@ -73,45 +78,48 @@ ball_x = 0.84
 ball_y = 0.55
 ball_z_start = 1.25
 ball_z_end = -3.0
-start_point = [ball_x,ball_y,ball_z_start]
-end_point = [ball_x,ball_y,ball_z_end]
-duration = 5.0 # seconds
-velocity = [0,0,(end_point[2]-start_point[2])/duration]
+start_point = [ball_x, ball_y, ball_z_start]
+end_point = [ball_x, ball_y, ball_z_end]
+duration = 5.0  # seconds
+velocity = [0, 0, (end_point[2] - start_point[2]) / duration]
 # "teleportation" to start point
 for dim in range(3):
-    frontend_ball.add_command(2*dim,
-                         o80.State1d(start_point[dim]),
-                         o80.Mode.QUEUE)
+    frontend_ball.add_command(2 * dim, o80.State1d(start_point[dim]), o80.Mode.QUEUE)
 # falling down to end point
 for dim in range(3):
-    frontend_ball.add_command(2*dim,
-                         o80.State1d(end_point[dim]),
-                         o80.Duration_us.seconds(int(duration)),
-                         o80.Mode.QUEUE)
-    frontend_ball.add_command(2*dim+1,
-                         o80.State1d(velocity[dim]),
-                         o80.Duration_us.seconds(int(duration)),
-                         o80.Mode.QUEUE)
+    frontend_ball.add_command(
+        2 * dim,
+        o80.State1d(end_point[dim]),
+        o80.Duration_us.seconds(int(duration)),
+        o80.Mode.QUEUE,
+    )
+    frontend_ball.add_command(
+        2 * dim + 1,
+        o80.State1d(velocity[dim]),
+        o80.Duration_us.seconds(int(duration)),
+        o80.Mode.QUEUE,
+    )
 
 
 # having the robot performing a hit motion
-robot_target1 = [-np.pi/4.0,+np.pi/3.0,0,0]
-robot_target = [o80.State2d(rt,0) for rt in robot_target1]
-for dof,target in enumerate(robot_target):
-    frontend_robot.add_command(dof,target,
-                               o80.Duration_us.milliseconds(700),
-                               o80.Mode.QUEUE)
+robot_target1 = [-np.pi / 4.0, +np.pi / 3.0, 0, 0]
+robot_target = [o80.State2d(rt, 0) for rt in robot_target1]
+for dof, target in enumerate(robot_target):
+    frontend_robot.add_command(
+        dof, target, o80.Duration_us.milliseconds(700), o80.Mode.QUEUE
+    )
 duration = 1
-robot_target2 = [+np.pi/2.0,+np.pi/3.0,0,-np.pi/8.0]
-robot_velocity = [ (rt2-rt1)/float(duration)
-                   for rt1,rt2 in zip(robot_target1,robot_target2) ]
-robot_target = [o80.State2d(rt,rv) for rt,rv in zip(robot_target2,robot_velocity)]
-for dof,target in enumerate(robot_target):
-    frontend_robot.add_command(dof,target,
-                               o80.Duration_us.seconds(duration),
-                               o80.Mode.QUEUE)
+robot_target2 = [+np.pi / 2.0, +np.pi / 3.0, 0, -np.pi / 8.0]
+robot_velocity = [
+    (rt2 - rt1) / float(duration) for rt1, rt2 in zip(robot_target1, robot_target2)
+]
+robot_target = [o80.State2d(rt, rv) for rt, rv in zip(robot_target2, robot_velocity)]
+for dof, target in enumerate(robot_target):
+    frontend_robot.add_command(
+        dof, target, o80.Duration_us.seconds(duration), o80.Mode.QUEUE
+    )
 
-    
+
 # sending ball trajectory and robot motion
 frontend_ball.pulse()
 frontend_robot.pulse()
@@ -123,19 +131,18 @@ time.sleep(1)
 time_start = time.time()
 first_contact_racket = False
 first_contact_table = False
-while time.time()-time_start < duration:
+while time.time() - time_start < duration:
     contacts_racket = pam_mujoco.get_contact("racket")
     if contacts_racket.contact_occured and not first_contact_racket:
         print("-- contact with racket")
-        first_contact_racket=True;
+        first_contact_racket = True
     contacts_table = pam_mujoco.get_contact("table")
     if contacts_table.contact_occured and not first_contact_table:
         print("-- contact with table")
-        print("\tposition:",",".join([str(a) for a in contacts_table.position]))
-        first_contact_table=True;
+        print("\tposition:", ",".join([str(a) for a in contacts_table.position]))
+        first_contact_table = True
     time.sleep(0.1)
-    
+
 # stopping the mujoco thread
 pam_mujoco.request_stop("mj")
 process.join()
-

--- a/demos/contact_table.py
+++ b/demos/contact_table.py
@@ -11,9 +11,7 @@ mujoco_id = "mj"
 
 # generates pamy.xml in pam_mujoco/models/tmp/
 model_name = "trajectory"
-items = pam_mujoco.model_factory(model_name,
-                                 table=True,
-                                 hit_point=True)
+items = pam_mujoco.model_factory(model_name, table=True, hit_point=True)
 
 # getting the items
 ball = items["ball"]
@@ -21,8 +19,7 @@ table = items["table"]
 hit_point = items["hit_point"]
 
 # running mujoco thread
-def execute_mujoco(mujoco_id,model_name,
-                   ball,hit_point,table):
+def execute_mujoco(mujoco_id, model_name, ball, hit_point, table):
     # init mujoco
     config = pam_mujoco.MujocoConfig()
     config.graphics = True
@@ -30,28 +27,35 @@ def execute_mujoco(mujoco_id,model_name,
     config.realtime = True
     pam_mujoco.init_mujoco(config)
     # adding the mirror ball controller
-    pam_mujoco.add_mirror_until_contact_free_joint("ball",
-                                                   ball.joint,
-                                                   ball.index_qpos,ball.index_qvel,
-                                                   "contact")
+    pam_mujoco.add_mirror_until_contact_free_joint(
+        "ball", ball.joint, ball.index_qpos, ball.index_qvel, "contact"
+    )
     # adding the hit point controller
-    pam_mujoco.add_mirror_free_joint("hit_point",
-                                     hit_point.joint,
-                                     hit_point.index_qpos,hit_point.index_qvel)
+    pam_mujoco.add_mirror_free_joint(
+        "hit_point", hit_point.joint, hit_point.index_qpos, hit_point.index_qvel
+    )
     # adding detection of contact between ball and table
-    pam_mujoco.add_table_contact_free_joint("contact",
-                                            ball.index_qpos,ball.index_qvel,
-                                            ball.geom,table.geom_plate)
+    pam_mujoco.add_table_contact_free_joint(
+        "contact", ball.index_qpos, ball.index_qvel, ball.geom, table.geom_plate
+    )
     # starting the thread
-    pam_mujoco.execute(mujoco_id,model_name)
+    pam_mujoco.execute(mujoco_id, model_name)
     # looping until requested to stop
     while not pam_mujoco.is_stop_requested(mujoco_id):
         time.sleep(0.01)
 
+
 # starting mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(mujoco_id,model_name,
-                                         ball,hit_point,table,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        mujoco_id,
+        model_name,
+        ball,
+        hit_point,
+        table,
+    ),
+)
 pam_mujoco.clear(mujoco_id)
 process.start()
 pam_mujoco.wait_for_mujoco(mujoco_id)
@@ -62,25 +66,22 @@ frontend_ball = o80_pam.MirrorFreeJointFrontEnd("ball")
 frontend_hit_point = o80_pam.MirrorFreeJointFrontEnd("hit_point")
 
 # dropping the ball on the table
-start_point = [1.0,2.0,1]
-end_point = [1.5,1.0,-1]
-duration = 2 # seconds
-velocity = [(e-s)/float(duration)
-            for e,s in zip(end_point,start_point)]
+start_point = [1.0, 2.0, 1]
+end_point = [1.5, 1.0, -1]
+duration = 2  # seconds
+velocity = [(e - s) / float(duration) for e, s in zip(end_point, start_point)]
 for dim in range(3):
-    frontend_ball.add_command(2*dim,
-                              o80.State1d(start_point[dim]),
-                              o80.Mode.QUEUE)
-    frontend_ball.add_command(2*dim+1,
-                              o80.State1d(velocity[dim]),
-                              o80.Mode.QUEUE)
+    frontend_ball.add_command(2 * dim, o80.State1d(start_point[dim]), o80.Mode.QUEUE)
+    frontend_ball.add_command(2 * dim + 1, o80.State1d(velocity[dim]), o80.Mode.QUEUE)
 for dim in range(3):
-    frontend_ball.add_command(2*dim,
-                              o80.State1d(end_point[dim]),
-                              o80.Duration_us.seconds(duration),
-                              o80.Mode.QUEUE)
+    frontend_ball.add_command(
+        2 * dim,
+        o80.State1d(end_point[dim]),
+        o80.Duration_us.seconds(duration),
+        o80.Mode.QUEUE,
+    )
 
-    
+
 frontend_ball.pulse()
 
 # monitoring contact ball/table
@@ -91,20 +92,15 @@ while True:
         # contact detected: moving the hit point at the contact
         # position
         position = contacts.position
-        print("contact:",position)
-        for dim,p in enumerate(position):
-            frontend_hit_point.add_command(2*dim,
-                                           o80.State1d(p),
-                                           o80.Mode.QUEUE)
+        print("contact:", position)
+        for dim, p in enumerate(position):
+            frontend_hit_point.add_command(2 * dim, o80.State1d(p), o80.Mode.QUEUE)
         frontend_hit_point.pulse()
         break
 
-    
+
 time.sleep(3)
-    
+
 # stopping the mujoco thread
 pam_mujoco.request_stop("mj")
 process.join()
-
-
-

--- a/demos/generate_models.py
+++ b/demos/generate_models.py
@@ -9,40 +9,53 @@ mujoco_id = "pam_mujoco_model_demo"
 
 # adding two robots
 robots = []
-robots.append(pam_mujoco.Robot(model_name,"robot1",[0,0,-0.5],None))
-robots.append(pam_mujoco.Robot(model_name,"robot2",[1.6,3.4,-0.5],[-1,0,0,0,-1,0]))
+robots.append(pam_mujoco.Robot(model_name, "robot1", [0, 0, -0.5], None))
+robots.append(
+    pam_mujoco.Robot(model_name, "robot2", [1.6, 3.4, -0.5], [-1, 0, 0, 0, -1, 0])
+)
 
 # adding a "grid" of balls
-grid = np.mgrid[-1:1.2:0.2, -1:1.2:0.2].reshape(2,-1).T
+grid = np.mgrid[-1:1.2:0.2, -1:1.2:0.2].reshape(2, -1).T
 balls = []
-for index,position in enumerate(grid):
-    position = list(position)+[1] # adding z
-    name = "ball"+str(index)
-    color = [abs(position[0]),0,abs(position[1]),1]
+for index, position in enumerate(grid):
+    position = list(position) + [1]  # adding z
+    name = "ball" + str(index)
+    color = [abs(position[0]), 0, abs(position[1]), 1]
     mass = 0.0027
     size = 0.02
-    balls.append(pam_mujoco.Ball(model_name,name,color=color,position=position,
-                                 size=size,mass=mass))
+    balls.append(
+        pam_mujoco.Ball(
+            model_name, name, color=color, position=position, size=size, mass=mass
+        )
+    )
 
 # adding a table (defaults params except position)
-tables = [pam_mujoco.Table(model_name,"table",position=[0.8,1.7,-0.475])]
+tables = [pam_mujoco.Table(model_name, "table", position=[0.8, 1.7, -0.475])]
 
 # adding 2 goals
-goals = [pam_mujoco.Goal(model_name,"goal1",position=[0.6,1.4,-0.45]),
-         pam_mujoco.Goal(model_name,"goal2",position=[0.4,2.0,-0.45],
-                         size=[0.05,0.0005],
-                         color=[1.0,0.2,0.2,1.0])]
+goals = [
+    pam_mujoco.Goal(model_name, "goal1", position=[0.6, 1.4, -0.45]),
+    pam_mujoco.Goal(
+        model_name,
+        "goal2",
+        position=[0.4, 2.0, -0.45],
+        size=[0.05, 0.0005],
+        color=[1.0, 0.2, 0.2, 1.0],
+    ),
+]
 
 # adding a "hit point"
-hit_points = [pam_mujoco.HitPoint(model_name,"hp",position=[0.7,1.0,-0.45])]
+hit_points = [pam_mujoco.HitPoint(model_name, "hp", position=[0.7, 1.0, -0.45])]
 
 # generating the model xml file (/tmp/test/test.xml)
-path = pam_mujoco.generate_model(model_name,
-                                 robots=robots,
-                                 balls=balls,
-                                 tables=tables,
-                                 goals=goals,
-                                 hit_points=hit_points)
+path = pam_mujoco.generate_model(
+    model_name,
+    robots=robots,
+    balls=balls,
+    tables=tables,
+    goals=goals,
+    hit_points=hit_points,
+)
 
 # starting mujoco using the generated model
 config = pam_mujoco.MujocoConfig()
@@ -50,7 +63,7 @@ config.graphics = True
 config.extended_graphics = False
 config.realtime = True
 pam_mujoco.init_mujoco(config)
-pam_mujoco.execute(mujoco_id,path)
+pam_mujoco.execute(mujoco_id, path)
 
 signal_handler.init()
 print("ctrl+c for exit")

--- a/demos/mirror_robot.py
+++ b/demos/mirror_robot.py
@@ -10,11 +10,11 @@ mujoco_id = "mj"
 
 # generates pamy.xml in pam_mujoco/models/tmp/
 model_name = "pamy"
-items = pam_mujoco.model_factory(model_name,table=True,robot1=True)
+items = pam_mujoco.model_factory(model_name, table=True, robot1=True)
 robot = items["robot"]
 
 # running the mujoco thread
-def execute_mujoco(segment_id,mujoco_id,model_name,robot):
+def execute_mujoco(segment_id, mujoco_id, model_name, robot):
     # init mujoco
     config = pam_mujoco.MujocoConfig()
     config.graphics = True
@@ -22,18 +22,26 @@ def execute_mujoco(segment_id,mujoco_id,model_name,robot):
     config.realtime = True
     pam_mujoco.init_mujoco(config)
     # adding mirroring robot controller
-    pam_mujoco.add_mirror_robot(segment_id,robot.joint)
+    pam_mujoco.add_mirror_robot(segment_id, robot.joint)
     # setting bursting mode
-    pam_mujoco.add_bursting(mujoco_id,segment_id)
+    pam_mujoco.add_bursting(mujoco_id, segment_id)
     # starting the mujoco thread (reads pamy.xml in pam_mujoco/models/tmp/)
-    pam_mujoco.execute(mujoco_id,model_name)
+    pam_mujoco.execute(mujoco_id, model_name)
     # runnign it until requested to stop
     while not pam_mujoco.is_stop_requested(mujoco_id):
         time.sleep(0.01)
 
+
 # starting the mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(segment_id,mujoco_id,model_name,robot,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        segment_id,
+        mujoco_id,
+        model_name,
+        robot,
+    ),
+)
 pam_mujoco.clear(mujoco_id)
 process.start()
 pam_mujoco.wait_for_mujoco(mujoco_id)
@@ -46,35 +54,32 @@ frontend = o80_pam.MirrorRobotFrontEnd(segment_id)
 # getting to init posture (all joints to pi/4)
 # in 3000 iteration
 nb_iterations = 500
-iterations = o80.Iteration(nb_iterations,True,True)
-state = o80.State2d(np.pi/4.0,0)
+iterations = o80.Iteration(nb_iterations, True, True)
+state = o80.State2d(np.pi / 4.0, 0)
 # adding a command for each joint
 for dof in range(4):
-    frontend.add_command(dof,state,iterations,o80.Mode.OVERWRITE)
+    frontend.add_command(dof, state, iterations, o80.Mode.OVERWRITE)
 # requesting mujoco to run 3000 iteration
 frontend.burst(nb_iterations)
 
 # moving 4 times the joints from -pi/4 to pi/4 and back
 for _ in range(4):
-    state = o80.State2d(-np.pi/4.0,0)
+    state = o80.State2d(-np.pi / 4.0, 0)
     for dof in range(4):
-        frontend.add_command(dof,state,iterations,o80.Mode.OVERWRITE)
+        frontend.add_command(dof, state, iterations, o80.Mode.OVERWRITE)
     frontend.burst(nb_iterations)
-    state = o80.State2d(+np.pi/4.0,0)
+    state = o80.State2d(+np.pi / 4.0, 0)
     for dof in range(4):
-        frontend.add_command(dof,state,iterations,o80.Mode.OVERWRITE)
+        frontend.add_command(dof, state, iterations, o80.Mode.OVERWRITE)
     frontend.burst(nb_iterations)
 
 # back to all joints at 0
-state = o80.State2d(0,0)
+state = o80.State2d(0, 0)
 for dof in range(4):
-    frontend.add_command(dof,state,iterations,o80.Mode.OVERWRITE)
+    frontend.add_command(dof, state, iterations, o80.Mode.OVERWRITE)
 frontend.burst(nb_iterations)
 
 # ending the mujoco thread
 pam_mujoco.request_stop("mj")
 frontend.final_burst()
 process.join()
-
-
-

--- a/demos/play_trajectories.py
+++ b/demos/play_trajectories.py
@@ -8,21 +8,23 @@ import multiprocessing
 
 mujoco_id = "mj"
 nb_balls = 5
-segment_ids = ["play_trajectories_"+str(index)
-               for index in range(nb_balls)]
+segment_ids = ["play_trajectories_" + str(index) for index in range(nb_balls)]
 
 # generates model in pam_mujoco/models/tmp/trajectories.xml
 model_name = "trajectories"
-ball_colors = [ [float(index)/float(nb_balls),0.0,1.0-float(index)/float(nb_balls),1.0]
-                for index in range(nb_balls) ]
-items = pam_mujoco.model_factory(model_name,table=True,
-                                 nb_balls=nb_balls,ball_colors=ball_colors)
+ball_colors = [
+    [float(index) / float(nb_balls), 0.0, 1.0 - float(index) / float(nb_balls), 1.0]
+    for index in range(nb_balls)
+]
+items = pam_mujoco.model_factory(
+    model_name, table=True, nb_balls=nb_balls, ball_colors=ball_colors
+)
 
 # getting the balls
 balls = items["balls"]
 
 # running mujoco thread
-def execute_mujoco(segment_ids,mujoco_id,model_name,balls):
+def execute_mujoco(segment_ids, mujoco_id, model_name, balls):
     # init mujoco
     config = pam_mujoco.MujocoConfig()
     config.graphics = True
@@ -30,23 +32,30 @@ def execute_mujoco(segment_ids,mujoco_id,model_name,balls):
     config.realtime = False
     pam_mujoco.init_mujoco(config)
     # adding the mirror ball controllers
-    for segment_id,ball in zip(segment_ids,balls):
-        pam_mujoco.add_mirror_free_joint(segment_id,
-                                         ball.joint,
-                                         ball.index_qpos,
-                                         ball.index_qvel)
+    for segment_id, ball in zip(segment_ids, balls):
+        pam_mujoco.add_mirror_free_joint(
+            segment_id, ball.joint, ball.index_qpos, ball.index_qvel
+        )
     # staring the thread
-    pam_mujoco.execute(mujoco_id,model_name)
+    pam_mujoco.execute(mujoco_id, model_name)
     # looping until requested to stop
     while not pam_mujoco.is_stop_requested(mujoco_id):
         time.sleep(0.01)
 
+
 # clearing shared memory from previous run
 pam_mujoco.clear(mujoco_id)
-        
+
 # starting mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(segment_ids,mujoco_id,model_name,balls,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        segment_ids,
+        mujoco_id,
+        model_name,
+        balls,
+    ),
+)
 process.start()
 
 # waiting for mujoco to startup
@@ -63,25 +72,31 @@ for segment_id in segment_ids:
     frontends.append(o80_pam.MirrorFreeJointFrontEnd(segment_id))
     trajectories.append(ball_trajectories.random_trajectory()[1])
 
-# preparing the full ball trajectories 
+# preparing the full ball trajectories
 # duration of 10ms : sampling rate of the trajectory
 duration = o80.Duration_us.milliseconds(10)
 for _ in range(3):
-    for segment_id,frontend,trajectory_points in zip(segment_ids,frontends,trajectories):
+    for segment_id, frontend, trajectory_points in zip(
+        segment_ids, frontends, trajectories
+    ):
         for traj_point in trajectory_points:
             # looping over x,y,z
             for dim in range(3):
                 # setting position for dimension (x, y or z)
-                frontend.add_command(2*dim,
-                                     o80.State1d(traj_point.position[dim]),
-                                     duration,
-                                     o80.Mode.QUEUE)
+                frontend.add_command(
+                    2 * dim,
+                    o80.State1d(traj_point.position[dim]),
+                    duration,
+                    o80.Mode.QUEUE,
+                )
                 # setting velocity for dimension (x, y or z)
-                frontend.add_command(2*dim+1,
-                                     o80.State1d(traj_point.velocity[dim]),
-                                     duration,
-                                     o80.Mode.QUEUE)
-        
+                frontend.add_command(
+                    2 * dim + 1,
+                    o80.State1d(traj_point.velocity[dim]),
+                    duration,
+                    o80.Mode.QUEUE,
+                )
+
 
 # sending the full ball trajectories to mujoco
 for frontend in frontends:
@@ -94,7 +109,3 @@ for frontend in frontends:
 # stopping the mujoco thread
 pam_mujoco.request_stop("mj")
 process.join()
-
-
-
-

--- a/demos/play_trajectory.py
+++ b/demos/play_trajectory.py
@@ -25,12 +25,12 @@ mujoco_id = "mj"
 
 # generates the mujoco xml model
 model_name = "trajectory"
-nb_balls = 2 # one playing the trajectory fully, the other until contact with table
-ball_colors = [[1,0,0,1],[0,0,1,1]]
+nb_balls = 2  # one playing the trajectory fully, the other until contact with table
+ball_colors = [[1, 0, 0, 1], [0, 0, 1, 1]]
 # we request the model to have 2 balls, and a table
-items = pam_mujoco.model_factory(model_name,
-                                 table=True,nb_balls=nb_balls,
-                                 ball_colors=ball_colors)
+items = pam_mujoco.model_factory(
+    model_name, table=True, nb_balls=nb_balls, ball_colors=ball_colors
+)
 
 # getting the items
 balls = items["balls"]
@@ -40,34 +40,39 @@ table = items["table"]
 model_path = items["path"]
 
 # running mujoco thread
-def execute_mujoco(mujoco_id,model_path,
-                   balls,table):
+def execute_mujoco(mujoco_id, model_path, balls, table):
     # init mujoco
     config = pam_mujoco.MujocoConfig()
     config.graphics = True
     config.extended_graphics = False
     config.realtime = True
     pam_mujoco.init_mujoco(config)
-    #for detecting contact with the table
-    pam_mujoco.add_table_contact("table",balls[1],table)
+    # for detecting contact with the table
+    pam_mujoco.add_table_contact("table", balls[1], table)
     # adding the mirror ball controller, full trajectory
-    pam_mujoco.add_o80_ball_control("ball1",balls[0])
+    pam_mujoco.add_o80_ball_control("ball1", balls[0])
     # adding the mirror ball controller, until contact with table
-    pam_mujoco.add_o80_ball_control_until_contact("ball2","table",balls[1])
+    pam_mujoco.add_o80_ball_control_until_contact("ball2", "table", balls[1])
     # starting the thread
-    pam_mujoco.execute(mujoco_id,model_path)
+    pam_mujoco.execute(mujoco_id, model_path)
     # looping until requested to stop
-    #while not pam_mujoco.is_stop_requested(mujoco_id):
+    # while not pam_mujoco.is_stop_requested(mujoco_id):
     #    time.sleep(0.01)
 
 
 # starting mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(mujoco_id,model_path,
-                                         balls,table,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        mujoco_id,
+        model_path,
+        balls,
+        table,
+    ),
+)
 pam_mujoco.clear(mujoco_id)
 process.start()
-pam_mujoco.wait_for_mujoco(mujoco_id,-1)
+pam_mujoco.wait_for_mujoco(mujoco_id, -1)
 
 # playing 3 trajectories
 for run in range(3):
@@ -78,65 +83,64 @@ for run in range(3):
     frontend_ball2 = o80_pam.BallFrontEnd("ball2")
 
     # reading a random pre-recorded ball trajectory
-    _,trajectory_points = list(context.BallTrajectories().random_trajectory())
+    _, trajectory_points = list(context.BallTrajectories().random_trajectory())
 
     # lowering the balls a bit to ensure contact with table
-    translation = [0,0,-0.01]
+    translation = [0, 0, -0.01]
     # sending the full ball trajectory to the mujoco thread.
     # duration of 10ms : sampling rate of the trajectory
     duration_s = 0.01
-    duration = o80.Duration_us.milliseconds(int(duration_s*1000))
+    duration = o80.Duration_us.milliseconds(int(duration_s * 1000))
     total_duration = duration_s * len(trajectory_points)
     for traj_point in trajectory_points:
-        translated_position = [p+t for p,t in zip(traj_point.position,translation)]
-        frontend_ball1.add_command(translated_position,traj_point.velocity,
-                             duration,o80.Mode.QUEUE)
-        frontend_ball2.add_command(translated_position,traj_point.velocity,
-                             duration,o80.Mode.QUEUE)
+        translated_position = [p + t for p, t in zip(traj_point.position, translation)]
+        frontend_ball1.add_command(
+            translated_position, traj_point.velocity, duration, o80.Mode.QUEUE
+        )
+        frontend_ball2.add_command(
+            translated_position, traj_point.velocity, duration, o80.Mode.QUEUE
+        )
 
-        
     # sending for full trajectory
     frontend_ball1.pulse()
     frontend_ball2.pulse()
 
     # first mujoco iterations place the balls to starting point
     time.sleep(0.1)
-        
+
     # starting iteration
     first_iteration = frontend_ball1.latest().get_iteration()
 
     # sanity check: ball2 touches the table
-    contact_detected=False
-    time_start=time.time()
-    while time.time()-time_start < total_duration:
+    contact_detected = False
+    time_start = time.time()
+    while time.time() - time_start < total_duration:
         contacts = pam_mujoco.get_contact("table")
         if contacts.contact_occured and not contact_detected:
             print("contact !")
-            contact_detected=True
+            contact_detected = True
         time.sleep(0.05)
 
     # computing the distance between the 2 balls
     # getting all observations (i.e. history of ball states
     # as recorded by the o80 backend in the shared memory)
     observations_ball1 = frontend_ball1.get_observations_since(first_iteration)
-    observations_ball2 = frontend_ball2.get_observations_since(first_iteration) 
+    observations_ball2 = frontend_ball2.get_observations_since(first_iteration)
     distances = []
-    for ball1,ball2 in zip(observations_ball1,observations_ball2):
+    for ball1, ball2 in zip(observations_ball1, observations_ball2):
         position1 = ball1.get_position()
         position2 = ball2.get_position()
-        distance = math.sqrt(sum([(p1-p2)**2 for p1,p2 in zip(position1,position2)]))
+        distance = math.sqrt(
+            sum([(p1 - p2) ** 2 for p1, p2 in zip(position1, position2)])
+        )
         distances.append(distance)
     # plotting the distance
-    plt.plot(range(len(distances)),distances)
+    plt.plot(range(len(distances)), distances)
     plt.show()
-    
-        
+
     # resetting contacts
     pam_mujoco.reset_contact("table")
-        
+
 # stopping the mujoco thread
 pam_mujoco.request_stop(mujoco_id)
 process.join()
-
-
-

--- a/demos/pressures.py
+++ b/demos/pressures.py
@@ -10,42 +10,53 @@ segment_id = "pressure_control"
 mujoco_id = "mj"
 
 model_name = "pressure"
-items = pam_mujoco.model_factory(model_name,robot1=True)
+items = pam_mujoco.model_factory(model_name, robot1=True)
 robot = items["robot"]
 
 # pam model configuration
-pam_model_config_path= pam_models.get_default_config_path()
-a_init = [0.5]*8
-l_MTC_change_init = [0.0]*8
+pam_model_config_path = pam_models.get_default_config_path()
+a_init = [0.5] * 8
+l_MTC_change_init = [0.0] * 8
 scale_max_activation = 1.0
 scale_max_pressure = 24000
 scale_min_activation = 0.001
 scale_min_pressure = 6000
-pam_model_config = [ segment_id,
-                     robot.joint,
-                     scale_min_pressure,scale_max_pressure,
-                     scale_min_activation, scale_max_activation,
-                     pam_model_config_path,pam_model_config_path,
-                     a_init,l_MTC_change_init ]
+pam_model_config = [
+    segment_id,
+    robot.joint,
+    scale_min_pressure,
+    scale_max_pressure,
+    scale_min_activation,
+    scale_max_activation,
+    pam_model_config_path,
+    pam_model_config_path,
+    a_init,
+    l_MTC_change_init,
+]
 
 # running the mujoco thread
-def execute_mujoco(pam_model_config,
-                   robot,
-                   mujoco_id,model_name):
+def execute_mujoco(pam_model_config, robot, mujoco_id, model_name):
     # init mujoco
     pam_mujoco.init_mujoco()
     # adding pressure controller
     pam_mujoco.add_pressure_controller(*pam_model_config)
     # starting the mujoco thread
-    pam_mujoco.execute(mujoco_id,model_name)
+    pam_mujoco.execute(mujoco_id, model_name)
     # runnign it until requested to stop
     while not pam_mujoco.is_stop_requested(mujoco_id):
         time.sleep(0.01)
 
+
 # starting the mujoco thread
-process  = multiprocessing.Process(target=execute_mujoco,
-                                   args=(pam_model_config,robot,
-                                         mujoco_id,model_name,))
+process = multiprocessing.Process(
+    target=execute_mujoco,
+    args=(
+        pam_model_config,
+        robot,
+        mujoco_id,
+        model_name,
+    ),
+)
 pam_mujoco.clear(mujoco_id)
 process.start()
 pam_mujoco.wait_for_mujoco(mujoco_id)
@@ -56,32 +67,34 @@ frontend = o80_pam.FrontEnd(segment_id)
 
 # sending some commands and printing robot state
 
-def go_to(ago_pressure,antago_pressure,duration,dofs=[0,1,2,3]):
+
+def go_to(ago_pressure, antago_pressure, duration, dofs=[0, 1, 2, 3]):
     for dof in dofs:
-        frontend.add_command(dof,
-                             ago_pressure,antago_pressure,
-                             o80.Duration_us.milliseconds(duration),
-                             o80.Mode.QUEUE)
+        frontend.add_command(
+            dof,
+            ago_pressure,
+            antago_pressure,
+            o80.Duration_us.milliseconds(duration),
+            o80.Mode.QUEUE,
+        )
     frontend.pulse_and_wait()
-    
+
+
 for _ in range(50):
-    
-    go_to(20000,20000,1000)
+
+    go_to(20000, 20000, 1000)
     for dof in range(4):
-        print("moving dof:",dof)
-        go_to(18000,22000,1000,dofs=[dof])
-        go_to(22000,18000,1000,dofs=[dof])
-        go_to(20000,20000,1500,dofs=[dof])
+        print("moving dof:", dof)
+        go_to(18000, 22000, 1000, dofs=[dof])
+        go_to(22000, 18000, 1000, dofs=[dof])
+        go_to(20000, 20000, 1500, dofs=[dof])
 
 print("releasing pressure")
-go_to(0,0,3000)
+go_to(0, 0, 3000)
 time.sleep(3)
-    
+
 
 # ending the mujoco thread
 pam_mujoco.request_stop("mj")
 frontend.final_burst()
 process.join()
-
-
-

--- a/python/pam_mujoco/models.py
+++ b/python/pam_mujoco/models.py
@@ -93,7 +93,6 @@ class Ball:
 
 
 class Table:
-
     def __init__(
         self,
         model_name,
@@ -113,11 +112,15 @@ class Table:
         # function (in this file)
         self.geom_plate = None
         self.geom_net = None
-        
 
     def get_xml(self):
         (xml, name_plate_geom, name_net_geom, nb_bodies) = xml_templates.get_table_xml(
-            self.name, self.model_name, self.position, self.size, self.color, self.xy_axes
+            self.name,
+            self.model_name,
+            self.position,
+            self.size,
+            self.color,
+            self.xy_axes,
         )
         return (xml, name_plate_geom, name_net_geom, nb_bodies)
 
@@ -275,11 +278,9 @@ def model_factory(
 
     tables = []
     if table is not None:
-        table = Table(model_name, 
-                      table.segment_id, 
-                      table.position, 
-                      table.size,
-                      table.orientation)
+        table = Table(
+            model_name, table.segment_id, table.position, table.size, table.orientation
+        )
         tables.append(table)
         r["table"] = table
     else:

--- a/python/pam_mujoco/mujoco_table.py
+++ b/python/pam_mujoco/mujoco_table.py
@@ -1,11 +1,10 @@
 class MujocoTable:
-
     def __init__(
-            self,
-            segment_id,
-            position=[0.1, 0.0, -0.44],
-            orientation="-1 0 0 0 -1 0",
-            size=[0.7625, 1.37, 0.02]
+        self,
+        segment_id,
+        position=[0.1, 0.0, -0.44],
+        orientation="-1 0 0 0 -1 0",
+        size=[0.7625, 1.37, 0.02],
     ):
 
         self.segment_id = segment_id

--- a/python/pam_mujoco/xml_templates.py
+++ b/python/pam_mujoco/xml_templates.py
@@ -75,8 +75,7 @@ def get_table_xml(model_name, name, position, size, color, xy_axes):
 
     template_body = '<body pos = "$position$" name = "$name$" xyaxes="$xy_axes$">'
     template_geom_plate = str(
-        '<geom name="$name_plate_geom$" type="box"'
-        + ' size="$size$" rgba="$color$" />'
+        '<geom name="$name_plate_geom$" type="box"' + ' size="$size$" rgba="$color$" />'
     )
 
     template_geom_leg = str(

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 setup_args = generate_distutils_setup(
-    packages=['pam_mujoco'],
-    package_dir={'': 'python'},
+    packages=["pam_mujoco"],
+    package_dir={"": "python"},
 )
 
 setup(**setup_args)


### PR DESCRIPTION
## Description

Run black to reformat all Python code.
This is a preparation to merging the github workflows which automatically check formatting for all pull requests.

## How I Tested

No tests done.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
