### PR TITLE
added o80_robot_ball_replay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,8 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/process_pam_visualization
   ${CMAKE_INSTALL_PREFIX}/bin/process_pam_visualization COPYONLY)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mirroring_real_robot
   ${CMAKE_INSTALL_PREFIX}/bin/pam_mirroring_real_robot COPYONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/o80_robot_ball_replay
+  ${CMAKE_INSTALL_PREFIX}/bin/o80_robot_ball_replay COPYONLY)
 
 
 ######################

--- a/bin/o80_robot_ball_replay
+++ b/bin/o80_robot_ball_replay
@@ -11,6 +11,7 @@ Required for this executable:
 - first in another terminal :'pam_mujoco robot_ball_replay'
 """
 
+import typing
 import pathlib
 import o80
 import signal_handler
@@ -95,6 +96,79 @@ def _get_handle() -> pam_mujoco.MujocoHandle:
     return handle
 
 
+def _add_ball_commands(
+    data: typing.Sequence[typing.Tuple], ball: o80_pam.MirrorFreeJointFrontEnd
+) -> None:
+    class _Data:
+        def __init__(self, d):
+            self.ball_id, self.stamp, self.position, self.velocity = d
+
+        def same(self, other):
+            return self.ball_id == other.ball_id
+
+        def duration(self, earlier):
+            return o80.Duration_us.nanoseconds(self.stamp - earlier.stamp)
+
+    previous = None
+
+    for d in data:
+        instance = _Data(d)
+        if previous is None:
+            previous = instance
+        if not instance.same(previous):
+            ball.add_command(
+                instance.position,
+                instance.velocity,
+                instance.duration(previous),
+                o80.Mode.QUEUE
+            )
+            previous = instance
+
+
+def _add_robot_commands(
+        data: typing.Sequence[typing.Tuple], robot: o80_pam.MirrorRobotFrontEnd
+) -> None:
+    class _Data:
+        def __init__(self, d):
+            self.stamp, self.positions, self.velocities = d
+
+        def same(self, other):
+            return self.stamp == other.stamp
+
+        def duration(self, earlier):
+            return o80.Duration_us.nanoseconds(self.stamp - earlier.stamp)
+
+    previous = None
+
+    for d in data:
+        instance = _Data(d)
+        if previous is None:
+            previous = instance
+        if not instance.same(previous):
+            robot.add_command(
+                instance.positions,
+                instance.velocities,
+                instance.duration(previous),
+                o80.Mode.QUEUE
+            )
+            previous = instance
+
+
+def _add_commands(
+        data: typing.Sequence[typing.Tuple[typing.Tuple,typing.Tuple]],
+    ball1: o80_pam.MirrorFreeJointFrontEnd,
+    ball2: o80_pam.MirrorFreeJointFrontEnd,
+    robot: o80_pam.MirrorRobotFrontEnd,
+) -> None:
+
+    d_ball = [d[0] for d in data]
+    d_robot = [d[1] for d in data]
+
+    _add_ball_commands(d_ball, ball1)
+    _add_ball_commands(d_ball, ball2)
+    _add_robot_commands(d_robot, robot)
+
+
 def run(filepath: pathlib.Path):
     """
     Parse filepath and plays the corresponding
@@ -114,32 +188,13 @@ def run(filepath: pathlib.Path):
     # parsing file
     data = list(o80_pam.robot_ball_parser.parse(filepath))
 
-    # duration between 2 ball observations
-    duration = int(data[1][0][1] - data[0][0][1]) * 1e-9
+    # loading all commands in the frontends
+    _add_commands(data, ball_real, ball_sim, robot)
 
-    # managing frequency corresponding to duration period
-    frequency_manager = o80.FrequencyManager(1.0 / float(duration))
-
-    # playing the ball trajectory
-    signal_handler.init()  # for detecting ctrl+c
-    previous_ball_id = None
-    previous_robot_time_stamp = None
-    for d in data:
-        frequency_manager.wait()
-        ball_id, _, ball_position, ball_velocity = d[0]
-        robot_time_stamp, robot_positions, robot_velocities = d[1]
-        if ball_id != previous_ball_id:
-            ball_real.add_command(ball_position, ball_velocity, o80.Mode.OVERWRITE)
-            ball_sim.add_command(ball_position, ball_velocity, o80.Mode.OVERWRITE)
-        if robot_time_stamp != previous_robot_time_stamp:
-            robot.add_command(robot_positions, robot_velocities, o80.Mode.OVERWRITE)
-        ball_real.pulse()
-        ball_sim.pulse()
-        robot.pulse()
-        previous_ball_id = ball_id
-        previous_robot_time_stamp = robot_time_stamp
-        if signal_handler.has_received_sigint():
-            break
+    # sending commands to pam mujoco
+    ball_real.pulse()
+    ball_sim.pulse()
+    robot.pulse_and_wait()
 
 
 if __name__ == "__main__":

--- a/bin/o80_robot_ball_replay
+++ b/bin/o80_robot_ball_replay
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+"""
+Display in a mujoco simulated environment the ball and the robot
+as logged in a o80_robot_ball_{x} file, i.e. a file
+generated via o80_robot_ball_logger.
+Two balls are displayed: the one mirroring the real ball (red),
+a second one (green) mirroring the real ball up to contact with the robot
+racket, then applying our custmor contact model.
+Required for this executable:
+- first in another terminal :'pam_mujoco robot_ball_replay'
+"""
+
+import pathlib
+import o80
+import signal_handler
+import o80_pam
+import pam_mujoco
+from lightargs import BrightArgs, FileExists
+
+DEFAULT_SAVE_FOLDER = pathlib.Path("/tmp")
+MUJOCO_ID = "robot_ball_replay"
+
+
+def _get_default_file(
+    directory: pathlib.Path, file_prefix="o80_robot_ball_*"
+) -> pathlib.Path:
+    """
+    Returns one of the file "/tmp/o80_robot_ball_*"
+    Return empty string if no such file.
+    """
+
+    for filename in directory.glob(file_prefix):
+        if filename.is_file():
+            return directory / filename
+
+    return ""
+
+
+def _configure() -> BrightArgs:
+    """
+    Configuration dialog
+    """
+
+    global DEFAULT_SAVE_FOLDER
+    config = BrightArgs("o80 robot ball replay")
+    config.add_option(
+        "filepath",
+        str(_get_default_file(DEFAULT_SAVE_FOLDER)),
+        "absolute path of the log file to replay",
+        str,
+        [FileExists()],
+    )
+    change_all = False
+    config.dialog(change_all)
+    print()
+    return config
+
+
+def _get_handle() -> pam_mujoco.MujocoHandle:
+    """
+    Configures mujoco to have a controllable ball
+    and returns the handle
+    """
+
+    global MUJOCO_ID
+    ball_real = pam_mujoco.MujocoItem(
+        "ball_real",
+        control=pam_mujoco.MujocoItem.COMMAND_ACTIVE_CONTROL,
+        color=(1, 0, 0, 1),
+    )
+    ball_sim = pam_mujoco.MujocoItem(
+        "ball_sim",
+        control=pam_mujoco.MujocoItem.COMMAND_ACTIVE_CONTROL,
+        contact_type=pam_mujoco.ContactTypes.racket1,  # applies custom contact model upon contact
+        color=(0, 1, 0, 1),
+    )
+    robot = pam_mujoco.MujocoRobot(
+        "robot",
+        control=pam_mujoco.MujocoRobot.JOINT_CONTROL,
+        active_only_control=pam_mujoco.MujocoRobot.COMMAND_ACTIVE_CONTROL,
+    )
+    table = pam_mujoco.MujocoTable("table")
+    graphics = True
+    accelerated_time = False
+    handle = pam_mujoco.MujocoHandle(
+        MUJOCO_ID,
+        table=table,
+        robot1=robot,
+        balls=(ball_real, ball_sim),
+        graphics=graphics,
+        accelerated_time=accelerated_time,
+        burst_mode=False,
+    )
+    return handle
+
+
+def run(filepath: pathlib.Path):
+    """
+    Parse filepath and plays the corresponding
+    ball trajectory in mujoco (via an o80 frontend)
+    """
+
+    # configuring and staring mujoco
+    handle = _get_handle()
+
+    # getting a frontend for balls control
+    ball_real = handle.frontends["ball_real"]
+    ball_sim = handle.frontends["ball_sim"]
+
+    # getting a frontend for robot control
+    robot = handle.frontends["robot"]
+
+    # parsing file
+    data = list(o80_pam.robot_ball_parser.parse(filepath))
+
+    # duration between 2 ball observations
+    duration = int(data[1][0][1] - data[0][0][1]) * 1e-9
+
+    # managing frequency corresponding to duration period
+    frequency_manager = o80.FrequencyManager(1.0 / float(duration))
+
+    # playing the ball trajectory
+    signal_handler.init()  # for detecting ctrl+c
+    previous_ball_id = None
+    previous_robot_time_stamp = None
+    for d in data:
+        frequency_manager.wait()
+        ball_id, _, ball_position, ball_velocity = d[0]
+        robot_time_stamp, robot_positions, robot_velocities = d[1]
+        if ball_id != previous_ball_id:
+            ball_real.add_command(ball_position, ball_velocity, o80.Mode.OVERWRITE)
+            ball_sim.add_command(ball_position, ball_velocity, o80.Mode.OVERWRITE)
+        if robot_time_stamp != previous_robot_time_stamp:
+            robot.add_command(robot_positions, robot_velocities, o80.Mode.OVERWRITE)
+        ball_real.pulse()
+        ball_sim.pulse()
+        robot.pulse()
+        previous_ball_id = ball_id
+        previous_robot_time_stamp = robot_time_stamp
+        if signal_handler.has_received_sigint():
+            break
+
+
+if __name__ == "__main__":
+    config = _configure()
+    run(pathlib.Path(config.filepath))

--- a/python/pam_mujoco/mujoco_robot.py
+++ b/python/pam_mujoco/mujoco_robot.py
@@ -14,7 +14,7 @@ class MujocoRobot:
     def __init__(
         self,
         segment_id,
-        position=[0.435, 0.1175, -0.0025],
+        position=[0.435, 0.1175, -0.0],
         orientation="-1 0 0 0 -1 0",
         control=NO_CONTROL,
         active_only_control=CONSTANT_CONTROL,

--- a/python/pam_mujoco/mujoco_table.py
+++ b/python/pam_mujoco/mujoco_table.py
@@ -2,7 +2,7 @@ class MujocoTable:
     def __init__(
         self,
         segment_id,
-        position=[0.1, 0.0, -0.44],
+        position=[0.8, 1.7, -0.475],
         orientation="-1 0 0 0 -1 0",
         size=[0.7625, 1.37, 0.02],
     ):


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The executable o80_robot_ball_logger from package o80_pam dumps information regarding the ball and robot positions and velocities in a file.
Added an executable o80_robot_ball_replay which parse such file and replays it in a mujoco simulation.
While the file contains info about only one ball, the executable displays 2 balls: one replays the dumped data, the other one replays the dumped data up to contact with the robot racket; and then the custom contact model is applied.


## How I Tested

Used to to replay a file recorded with o80_robot_ball_logger

## Do not merge before

https://github.com/intelligent-soft-robots/o80_pam/pull/7

- [x] link to dependent pull request

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ x] All new functions/classes are documented and existing documentation is updated according to changes.
- [ x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
