### PR TITLE
handle waiting for pam_mujoco to create the segment

### DIFF
--- a/python/pam_mujoco/mujoco_handle.py
+++ b/python/pam_mujoco/mujoco_handle.py
@@ -295,12 +295,28 @@ class MujocoHandle:
                     if r:
                         config.add_control(r)
 
+            # waiting for pam_mujoco to have created the shared memory segment_id
+
+            logging.info("waiting for pam_mujoco {}".format(mujoco_id))
+            created = False
+            while not created:
+                created = shared_memory.wait_for_segment(mujoco_id,100)
+                
+                        
             # writing the mujoco config in the shared memory.
             # the mujoco executable is expected to read it and start
 
             logging.info("sharing mujoco configuration for {}".format(mujoco_id))
 
             pam_mujoco_wrp.set_mujoco_config(config)
+
+
+        # waiting for pam_mujoco to have created the shared memory segment_id
+        
+        logging.info("waiting for pam_mujoco {}".format(mujoco_id))
+        created = False
+        while not created:
+            created = shared_memory.wait_for_segment(mujoco_id,100)
 
         # waiting for mujoco to report it is ready
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Because the handle constructor relies on a shared memory segment created by pam_mujoco, pam_mujoco has to be fully started before a handle is created, which can be problematic. 
Update: the handle waits for the segment to have been created, which solves the issue above.
Limitation: fails if a deprecated segment from a previous run has not been cleaned.

## How I Tested

- Created a handle before starting pam_mujoco: it worked
- Starting pam_mujoco before creating the handle: it worked


## I fulfilled the following requirements

This code requires some cleanup.