### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/pam_mujoco/mirror_free_joint.hxx
+++ b/include/pam_mujoco/mirror_free_joint.hxx
@@ -40,7 +40,7 @@ void MirrorFreeJoint<QUEUE_SIZE>::set_contact_interrupt(std::string segment_id)
 template <int QUEUE_SIZE>
 void MirrorFreeJoint<QUEUE_SIZE>::apply(const mjModel* m, mjData* d)
 {
-   (void)(m);
+    (void)(m);
     if (this->must_update(d))
     {
         read_states_.values[0].value = d->qpos[index_qpos_];
@@ -62,7 +62,7 @@ void MirrorFreeJoint<QUEUE_SIZE>::apply(const mjModel* m, mjData* d)
     // take hand), checking if such contact occured.
     // (note: see Contacts.hpp to see what serialize ContactInformation
     // instances into the shared memory)
-    bool contact_disabled=false;
+    bool contact_disabled = false;
     if (contact_interrupt_)
     {
         context::ContactInformation ci;

--- a/include/pam_mujoco/mirror_free_joints.hxx
+++ b/include/pam_mujoco/mirror_free_joints.hxx
@@ -146,7 +146,7 @@ void MirrorFreeJoints<QUEUE_SIZE, NB_ITEMS>::apply(const mjModel* m, mjData* d)
         // take hand), checking if such contact occured.
         // (note: see Contacts.hpp to check what serializes ContactInformation
         // instances into the shared memory)
-        bool contact_disabled=false;
+        bool contact_disabled = false;
         // the ball is set to have control interrupted in case of contact
         if (contact_interrupt_[index])
         {

--- a/include/pam_mujoco/pressure_controller.hxx
+++ b/include/pam_mujoco/pressure_controller.hxx
@@ -143,7 +143,8 @@ mjtNum PressureController<QUEUE_SIZE, NB_DOFS>::get_bias(const mjModel* m,
                                                          const mjData* d,
                                                          int id)
 {
-  (void)(m); (void)(d);
+    (void)(m);
+    (void)(d);
     int i_muscle = id - 2 * NB_DOFS;
     return -bias_forces_[i_muscle];  // computed in the apply function
     // note: optional filtering performed in the original code, ignored for now

--- a/src/is_in_contact.cpp
+++ b/src/is_in_contact.cpp
@@ -5,7 +5,7 @@ namespace pam_mujoco
 {
 namespace internal
 {
-bool is_in_contact(const mjModel* m,
+bool is_in_contact(const mjModel*,
                    mjData* d,
                    int index_geom,
                    int index_geom_contactee)


### PR DESCRIPTION
## Description

Followup on #20, fixing the remaining warnings in this package.  See commits for details.

**Open question:** The last commit initialises `contact_disabled` in `mirror_free_joint[s].hxx` which was potentially used uninitialised.  I set it to false now, but I'm not sure if this is a good default.  Let me know if I should rather initialise it to true.

## How I Tested

By building and running unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
