### PR TITLE
Add launch_pam_mujoco_xterm to run in xterm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR python/${PROJECT_NAME})
 ######################
 
 install(PROGRAMS
+    bin/launch_pam_mujoco_xterm
     bin/pam_mujoco
     bin/pam_mujoco_no_xterms
     bin/pam_mujoco_stop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,33 +152,23 @@ install(TARGETS ${PROJECT_NAME}_py DESTINATION ${PYTHON_INSTALL_DIR})
 ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR python/${PROJECT_NAME})
 
 
-###############
-# Executables #
-###############
-
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mujoco
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mujoco COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mujoco_no_xterms
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mujoco_no_xterms COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mujoco_stop
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mujoco_stop COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mujoco_stop_all
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mujoco_stop_all COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mujoco_visualization
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mujoco_visualization COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mujoco_visualization_no_xterms
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mujoco_visualization_no_xterms COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/process_pam_visualization
-  ${CMAKE_INSTALL_PREFIX}/bin/process_pam_visualization COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/pam_mirroring_real_robot
-  ${CMAKE_INSTALL_PREFIX}/bin/pam_mirroring_real_robot COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/bin/o80_robot_ball_replay
-  ${CMAKE_INSTALL_PREFIX}/bin/o80_robot_ball_replay COPYONLY)
-
-
 ######################
 # Install and export #
 ######################
+
+install(PROGRAMS
+    bin/pam_mujoco
+    bin/pam_mujoco_no_xterms
+    bin/pam_mujoco_stop
+    bin/pam_mujoco_stop_all
+    bin/pam_mujoco_visualization
+    bin/pam_mujoco_visualization_no_xterms
+    bin/process_pam_visualization
+    bin/pam_mirroring_real_robot
+    bin/o80_robot_ball_replay
+
+    DESTINATION bin
+)
 
 install(DIRECTORY include/ DESTINATION include)
 install(

--- a/bin/launch_pam_mujoco_xterm
+++ b/bin/launch_pam_mujoco_xterm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ $# != 1 ]; then
+    >&2 echo "Invalid number of arguments"
+    >&2 echo "Usage: $0 <mujoco_id>"
+    exit 1
+fi
+
+mujoco_id="$1"
+
+exec xterm -T "$mujoco_id" -n "$mujoco_id" -e launch_pam_mujoco "$mujoco_id"

--- a/bin/pam_mujoco
+++ b/bin/pam_mujoco
@@ -2,8 +2,7 @@
 
 for mujoco_id in "$@"
 do
-
-    xterm -T "$mujoco_id" -n "$mujoco_id" -e launch_pam_mujoco "$mujoco_id" &
+    launch_pam_mujoco_xterm "$mujoco_id" &
     pid=$!
     echo "launch_pam_mujoco ${mujoco_id} pid: ${pid}"
 done


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add `launch_pam_mujoco_xterm` to run in xterm in a separate script, so it can also be used directly without sending the process to the background.

Refactor CMakeLists.txt: Use `install(PROGRAMS ...)` to install the scripts.  This makes it more readable and also ensures that the installed scripts are executable (even if the original files are not).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
