### PR TITLE
fix broken build

### DIFF
--- a/src/is_in_contact.cpp
+++ b/src/is_in_contact.cpp
@@ -10,7 +10,6 @@ bool is_in_contact(const mjModel*,
                    int index_geom,
                    int index_geom_contactee)
 {
-  (void)(m);
     for (int i = 0; i < d->ncon; i++)
     {
         if (d->contact[i].geom1 == index_geom &&


### PR DESCRIPTION
## Description

This was probably caused by merging two concurrent attempts to fix the "unused parameter" warning.


## How I Tested

By building the code.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
