### PR TITLE
Remove obsolete traces of catkin 

### DIFF
--- a/doc/01.installation.md
+++ b/doc/01.installation.md
@@ -28,7 +28,7 @@ cd Pam
 git clone https://github.com/intelligent-soft-robots/treep_isr
 treep --clone PAM_MUJOCO
 cd workspace
-catkin build
+colcon build
 ```
 
 ## sourcing the workspace

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-setup_args = generate_distutils_setup(
-    packages=["pam_mujoco"],
-    package_dir={"": "python"},
-)
-
-setup(**setup_args)


### PR DESCRIPTION
## Description

- Remove setup.py.  It was used by catkin and is not needed for colcon.
- Update documentation to use `colcon build` instead of `catkin build`.

## How I Tested
Rebuilt workspace and manually verified that the Python packages are still importable.