### PR TITLE
update of contactee cartesian state only on position update

### DIFF
--- a/include/pam_mujoco/internal/contact_states.hpp
+++ b/include/pam_mujoco/internal/contact_states.hpp
@@ -36,6 +36,7 @@ public:
     std::array<double, 3> ball_position;
     std::array<double, 3> ball_velocity;
     double time_stamp;
+    double velocity_time_stamp;
 };
 
 /**

--- a/src/contact_states.cpp
+++ b/src/contact_states.cpp
@@ -4,8 +4,27 @@ namespace pam_mujoco
 {
 namespace internal
 {
-ContactStates::ContactStates() : time_stamp(-1)
+ContactStates::ContactStates() : time_stamp(-1), velocity_time_stamp(-1)
 {
+}
+
+bool should_update_velocity(internal::ContactStates& previous_state,
+                            mjtNum* m,
+                            double time,
+                            double time_threshold = 0.1)
+{
+    for (size_t i = 0; i < 3; i++)
+    {
+        if (previous_state.contactee_position[i] != m[i])
+        {
+            return true;
+        }
+    }
+    if ((time - previous_state.velocity_time_stamp) >= time_threshold)
+    {
+        return true;
+    }
+    return false;
 }
 
 /**
@@ -34,15 +53,31 @@ void save_state(const mjData* d,
         double delta_time = d->time - get_states.time_stamp;
         if (delta_time != 0)
         {
-            for (size_t i = 0; i < 3; i++)
+            // ! this is quite hacky.
+            // When running learning_table_tennis_from_scratch, the positions of
+            // the robot joints are updated at a lower frequency: during the
+            // intermediate iterations, this thread "sees" an immobile racket,
+            // i.e. a velocity of zero, which is incorrect.
+            // "should_update_velocity" returns true only if the racket moved,
+            // or if a time threshold passed.
+            if (should_update_velocity(
+                    get_states,
+                    &(d->geom_xpos[index_geom_contactee * 3]),
+                    d->time))
             {
-                get_states.contactee_velocity[i] =
-                    (d->geom_xpos[index_geom_contactee * 3 + i] -
-                     get_states.contactee_position[i]) /
-                    delta_time;
+                double dt = d->time - get_states.velocity_time_stamp;
+                for (size_t i = 0; i < 3; i++)
+                {
+                    get_states.contactee_velocity[i] =
+                        (d->geom_xpos[index_geom_contactee * 3 + i] -
+                         get_states.contactee_position[i]) /
+                        dt;
+                }
+                get_states.velocity_time_stamp = d->time;
             }
         }
     }
+
     // rest is just copied from d to get_states
     for (size_t i = 0; i < 3; i++)
     {

--- a/src/contact_states.cpp
+++ b/src/contact_states.cpp
@@ -11,11 +11,12 @@ ContactStates::ContactStates() : time_stamp(-1), velocity_time_stamp(-1)
 bool should_update_velocity(internal::ContactStates& previous_state,
                             mjtNum* m,
                             double time,
-                            double time_threshold = 0.1)
+                            double time_threshold = 0.1,
+                            double position_threshold = 0.0000001)
 {
     for (size_t i = 0; i < 3; i++)
     {
-        if (previous_state.contactee_position[i] != m[i])
+        if (abs(previous_state.contactee_position[i] - m[i])>position_threshold)
         {
             return true;
         }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

When running "learning table tennis from scratch", the position of the robot is mirrored at a lower frequency than the frequency of the simulated robot. Thus, for some iteration, the simulated robot "believes" the robot does not move (i.e. cartesian velocity of the racket is zero), which does not correspond to the state of the real robot.

This updates forces the cartesian velocity of the racket to be recomputed only if there is a change in position (i.e. new mirroring information have been set) or in case a time out passed.

This is quite hacky, so any better solution would be welcomed.

note: I considered having mujoco moving the robot based on its engine during the intermediate iteration, but this may result in a more incorrect velocity, e.g. if mujoco "overshoot" the cartesian position of the real robot, when new mirroring information is set, the velocity may incorrectly change direction.


## How I Tested

- fixed the issue on simulation.
