### PR TITLE
Use scipy Rotation for robot and table orientations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ ament_package()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
 
   # ignored for now
   # ament_add_gtest(test_${PROJECT_NAME}_cpp tests/main.cpp tests/unittests.cpp)
@@ -235,5 +236,7 @@ if(BUILD_TESTING)
       $<INSTALL_INTERFACE:include>
   )
   target_link_libraries(test_mj_state_tools mj_state_tools)
+
+  ament_add_pytest_test(test_xml_templates tests/test_xml_templates.py)
 
 endif()

--- a/mypy_stubs/scipy/__init__.pyi
+++ b/mypy_stubs/scipy/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/mypy_stubs/scipy/spatial/__init__.pyi
+++ b/mypy_stubs/scipy/spatial/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/mypy_stubs/scipy/spatial/transform.pyi
+++ b/mypy_stubs/scipy/spatial/transform.pyi
@@ -1,0 +1,107 @@
+# This file is copied from scipy _rotation.pyi with minimal modifications
+#
+#
+# Copyright (c) 2001-2002 Enthought, Inc. 2003-2023, SciPy Developers.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Union, Tuple, Optional, Sequence, Any
+import numpy as np
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+_IntegerType = Union[int, np.integer]
+
+def __getattr__(name: str) -> Any: ...
+
+class Rotation:
+    def __init__(
+        self, quat: npt.ArrayLike, normalize: bool = ..., copy: bool = ...
+    ) -> None: ...
+    @property
+    def single(self) -> bool: ...
+    def __len__(self) -> int: ...
+    @classmethod
+    def from_quat(cls, quat: npt.ArrayLike) -> Rotation: ...
+    @classmethod
+    def from_matrix(cls, matrix: npt.ArrayLike) -> Rotation: ...
+    @classmethod
+    def from_rotvec(cls, rotvec: npt.ArrayLike) -> Rotation: ...
+    @classmethod
+    def from_euler(
+        cls, seq: str, angles: Union[float, npt.ArrayLike], degrees: bool = ...
+    ) -> Rotation: ...
+    @classmethod
+    def from_mrp(cls, mrp: npt.ArrayLike) -> Rotation: ...
+    def as_quat(self) -> np.ndarray: ...
+    def as_matrix(self) -> np.ndarray: ...
+    def as_rotvec(self) -> np.ndarray: ...
+    def as_euler(self, seq: str, degrees: bool = ...) -> np.ndarray: ...
+    def as_mrp(self) -> np.ndarray: ...
+    @classmethod
+    def concatenate(cls, rotations: Sequence[Rotation]) -> Rotation: ...
+    def apply(self, vectors: npt.ArrayLike, inverse: bool = ...) -> np.ndarray: ...
+    def __mul__(self, other: Rotation) -> Rotation: ...
+    def inv(self) -> Rotation: ...
+    def magnitude(self) -> Union[np.ndarray, float]: ...
+    def mean(self, weights: Optional[npt.ArrayLike] = ...) -> Rotation: ...
+    def reduce(
+        self,
+        left: Optional[Rotation] = ...,
+        right: Optional[Rotation] = ...,
+        return_indices: bool = ...,
+    ) -> Union[Rotation, Tuple[Rotation, np.ndarray, np.ndarray]]: ...
+    @classmethod
+    def create_group(cls, group: str, axis: str = ...) -> Rotation: ...
+    def __getitem__(self, indexer: Union[int, slice, npt.ArrayLike]) -> Rotation: ...
+    @classmethod
+    def identity(cls, num: Optional[int] = ...) -> Rotation: ...
+    @classmethod
+    def random(
+        cls,
+        num: Optional[int] = ...,
+        random_state: Optional[
+            Union[_IntegerType, np.random.Generator, np.random.RandomState]
+        ] = ...,
+    ) -> Rotation: ...
+    @classmethod
+    def align_vectors(
+        cls,
+        a: npt.ArrayLike,
+        b: npt.ArrayLike,
+        weights: Optional[npt.ArrayLike] = ...,
+        return_sensitivity: bool = ...,
+    ) -> Union[Tuple[Rotation, float], Tuple[Rotation, float, np.ndarray]]: ...
+
+class Slerp:
+    def __init__(self, times: npt.ArrayLike, rotations: Rotation) -> None: ...
+    def __call__(self, times: npt.ArrayLike) -> Rotation: ...

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <depend>mujoco_interface</depend>
   
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.mypy]
+mypy_path = "$MYPY_CONFIG_FILE_DIR/mypy_stubs"
+
 [[tool.mypy.overrides]]
 module = [
     "context",

--- a/python/pam_mujoco/models.py
+++ b/python/pam_mujoco/models.py
@@ -1,5 +1,7 @@
 import typing as t
 
+from scipy.spatial.transform import Rotation
+
 from .mujoco_robot import MujocoRobot
 from .mujoco_table import MujocoTable
 from .robot_type import RobotType
@@ -125,7 +127,7 @@ class Robot:
         model_name: str,
         name: str,
         position: t.Sequence[float],
-        orientation: str,
+        orientation: Rotation,
         muscles: bool,
     ) -> None:
         self.robot_type = robot_type

--- a/python/pam_mujoco/models.py
+++ b/python/pam_mujoco/models.py
@@ -95,27 +95,33 @@ class Ball:
 
 class Table:
     def __init__(
-        self, model_name, name, position, size, xy_axes, color=[0.05, 0.3, 0.23, 1.0]
-    ):
+        self,
+        model_name: str,
+        name: str,
+        position: t.Sequence[float],
+        size: t.Sequence[float],
+        orientation: Rotation,
+        color: t.Tuple[float, float, float, float] = (0.05, 0.3, 0.23, 1.0),
+    ) -> None:
         self.model_name = model_name
         self.name = name
         self.position = position
         self.size = size
         self.color = color
-        self.xy_axes = xy_axes
-        # will be filled by the "generate_model"
-        # function (in this file)
-        self.geom_plate = None
-        self.geom_net = None
+        self.orientation = orientation
 
-    def get_xml(self):
+        # will be filled by the "generate_model" function (in this file)
+        self.geom_plate: t.Optional[str] = None
+        self.geom_net: t.Optional[str] = None
+
+    def get_xml(self) -> t.Tuple[str, str, str, int]:
         (xml, name_plate_geom, name_net_geom, nb_bodies) = xml_templates.get_table_xml(
             self.name,
             self.model_name,
             self.position,
             self.size,
             self.color,
-            self.xy_axes,
+            self.orientation,
         )
         return (xml, name_plate_geom, name_net_geom, nb_bodies)
 

--- a/python/pam_mujoco/mujoco_robot.py
+++ b/python/pam_mujoco/mujoco_robot.py
@@ -1,3 +1,6 @@
+import pathlib
+import typing as t
+
 import pam_models
 import pam_interface
 from .robot_type import RobotType
@@ -14,17 +17,19 @@ class MujocoRobot:
     def __init__(
         self,
         robot_type: RobotType,
-        segment_id,
-        position=(0.0, 0.0, 1.21),
-        orientation="0.0 0.0 0.0",
-        control=NO_CONTROL,
-        active_only_control=CONSTANT_CONTROL,
-        json_control_path=None,
-        json_ago_hill_path=None,
-        json_antago_hill_path=None,
+        segment_id: str,
+        position: t.Sequence[float] = (0.0, 0.0, 1.21),
+        orientation: str = "0.0 0.0 0.0",
+        control: int = NO_CONTROL,
+        active_only_control: int = CONSTANT_CONTROL,
+        json_control_path: t.Optional[pathlib.Path] = None,
+        json_ago_hill_path: t.Optional[pathlib.Path] = None,
+        json_antago_hill_path: t.Optional[pathlib.Path] = None,
     ) -> None:
         if json_control_path is None:
-            json_control_path = pam_interface.Pamy2DefaultConfiguration.get_path(True)
+            json_control_path = pathlib.Path(
+                pam_interface.Pamy2DefaultConfiguration.get_path(True)
+            )
         if json_ago_hill_path is None:
             json_ago_hill_path = pam_models.get_default_config_path()
         if json_antago_hill_path is None:

--- a/python/pam_mujoco/mujoco_robot.py
+++ b/python/pam_mujoco/mujoco_robot.py
@@ -1,6 +1,8 @@
 import pathlib
 import typing as t
 
+from scipy.spatial.transform import Rotation
+
 import pam_models
 import pam_interface
 from .robot_type import RobotType
@@ -19,13 +21,15 @@ class MujocoRobot:
         robot_type: RobotType,
         segment_id: str,
         position: t.Sequence[float] = (0.0, 0.0, 1.21),
-        orientation: str = "0.0 0.0 0.0",
+        orientation: t.Optional[Rotation] = None,
         control: int = NO_CONTROL,
         active_only_control: int = CONSTANT_CONTROL,
         json_control_path: t.Optional[pathlib.Path] = None,
         json_ago_hill_path: t.Optional[pathlib.Path] = None,
         json_antago_hill_path: t.Optional[pathlib.Path] = None,
     ) -> None:
+        if orientation is None:
+            orientation = Rotation.identity()
         if json_control_path is None:
             json_control_path = pathlib.Path(
                 pam_interface.Pamy2DefaultConfiguration.get_path(True)

--- a/python/pam_mujoco/mujoco_robot.py
+++ b/python/pam_mujoco/mujoco_robot.py
@@ -15,14 +15,21 @@ class MujocoRobot:
         self,
         robot_type: RobotType,
         segment_id,
-        position=[0.0, 0.0, 1.21],
+        position=(0.0, 0.0, 1.21),
         orientation="0.0 0.0 0.0",
         control=NO_CONTROL,
         active_only_control=CONSTANT_CONTROL,
-        json_control_path=pam_interface.Pamy2DefaultConfiguration.get_path(True),
-        json_ago_hill_path=pam_models.get_default_config_path(),
-        json_antago_hill_path=pam_models.get_default_config_path(),
-    ):
+        json_control_path=None,
+        json_ago_hill_path=None,
+        json_antago_hill_path=None,
+    ) -> None:
+        if json_control_path is None:
+            json_control_path = pam_interface.Pamy2DefaultConfiguration.get_path(True)
+        if json_ago_hill_path is None:
+            json_ago_hill_path = pam_models.get_default_config_path()
+        if json_antago_hill_path is None:
+            json_antago_hill_path = pam_models.get_default_config_path()
+
         self.robot_type = robot_type
         self.segment_id = segment_id
         self.position = position

--- a/python/pam_mujoco/mujoco_table.py
+++ b/python/pam_mujoco/mujoco_table.py
@@ -1,11 +1,19 @@
+import typing as t
+
+from scipy.spatial.transform import Rotation
+
+
 class MujocoTable:
     def __init__(
         self,
-        segment_id,
-        position=[+0.4, +1.57, 0.755],
-        orientation="0 0 0",
-        size=[0.7625, 1.37, 0.02],
-    ):
+        segment_id: str,
+        position: t.Sequence[float] = (0.4, 1.57, 0.755),
+        orientation: t.Optional[Rotation] = None,
+        size: t.Sequence[float] = (0.7625, 1.37, 0.02),
+    ) -> None:
+        if orientation is None:
+            orientation = Rotation.identity()
+
         self.segment_id = segment_id
         self.position = position
         self.orientation = orientation

--- a/python/pam_mujoco/xml_templates.py
+++ b/python/pam_mujoco/xml_templates.py
@@ -132,7 +132,7 @@ def get_robot_xml(
     model_name: str,
     name: str,
     position: t.Union[str, t.Iterable[float]],
-    orientation: t.Union[str, t.Iterable[float]],
+    orientation: t.Optional[Rotation],
     muscles: bool,
     robot_type: RobotType,
 ) -> t.Tuple[str, str, str, int]:
@@ -143,10 +143,10 @@ def get_robot_xml(
 
     optional = {}
     if orientation is not None:
-        optional["orientation"] = orientation
+        optional["mujoco_quat"] = _mujoco_quaternion(orientation)
 
         template = """
-            <body name="{name}" pos="{position}" euler="{orientation}">
+            <body name="{name}" pos="{position}" quat="{mujoco_quat}">
               <include file="{filename}"/>
             </body>
         """

--- a/python/pam_mujoco/xml_templates.py
+++ b/python/pam_mujoco/xml_templates.py
@@ -3,6 +3,7 @@ import typing as t
 from collections.abc import Iterable
 
 import numpy as np
+from scipy.spatial.transform import Rotation
 
 from . import paths
 from .robot_type import RobotType
@@ -35,6 +36,12 @@ def _from_template(template: str, /, **kwargs) -> str:
     result = template.format(**values)
 
     return result
+
+
+def _mujoco_quaternion(rotation: Rotation) -> np.ndarray:
+    """Convert a Rotation object to a MuJoCo-compatible quaternion (w, x, y, z)."""
+    # roll moves the `w` from the last position to the first
+    return np.roll(rotation.as_quat(), 1)
 
 
 def get_free_joint_body_xml(model_name, name, geom_type, position, size, color, mass):

--- a/tests/test_xml_templates.py
+++ b/tests/test_xml_templates.py
@@ -1,10 +1,36 @@
+import pathlib
+import re
+
 import numpy as np
+import pytest
 from scipy.spatial.transform import Rotation
 
+import pam_mujoco
 import pam_mujoco.xml_templates as m
 
 
-def test_mujoco_quaternion():
+def test_str() -> None:
+    assert m._str("foo") == "foo"
+    assert m._str(42) == "42"
+    assert m._str([1, 2, 3]) == "1 2 3"
+    assert m._str((1, 2, 3)) == "1 2 3"
+    assert m._str(np.array((1, 2, 3))) == "1 2 3"
+
+
+def test_from_template() -> None:
+    tmpl = "Test {foo} template {bar}"
+    assert m._from_template(tmpl, foo="hello", bar=42) == "Test hello template 42"
+    # unused values should silently be ignored
+    assert (
+        m._from_template(tmpl, foo="hello", bar=42, baz="unused")
+        == "Test hello template 42"
+    )
+
+    with pytest.raises(KeyError):
+        m._from_template(tmpl, foo="hello")  # bar missing
+
+
+def test_mujoco_quaternion() -> None:
     quat_xyzw = np.array([0.09365858, 0.18731716, 0.28097574, 0.93658581])
     quat_wxyz = np.array([0.93658581, 0.09365858, 0.18731716, 0.28097574])
 
@@ -12,3 +38,68 @@ def test_mujoco_quaternion():
     result = m._mujoco_quaternion(rot)
 
     np.testing.assert_array_almost_equal(result, quat_wxyz)
+
+
+def test_get_table_xml() -> None:
+    out_xml, out_name_plate_geom, out_name_net_geom, out_nb_bodies = m.get_table_xml(
+        "MODEL-NAME",
+        "NAME",
+        [0, 1, 2],
+        [1, 2, 0.1],
+        (1.0, 0, 0, 1.0),
+        Rotation.from_quat(np.array([0.0, 0.0, 0.4472136, 0.89442719])),
+    )
+
+    # strip whitespaces
+    out_xml = re.sub(" +", " ", out_xml.strip())
+
+    assert out_xml == (
+        '<body pos="0 1 2" name="NAME"'
+        ' quat="0.8944271889999159 0.0 0.0 0.4472135994999579">\n'
+        '<geom name="NAME_plate" type="box" size="1 2 0.1" rgba="1.0 0 0 1.0" />\n'
+        '<geom name="NAME_net" pos="0.0 0.0 0.07625" type="box"'
+        ' size="0.7825 0.02 0.07625" rgba="0.1 0.1 0.1 0.4"/>\n'
+        '<geom name="leg_0" pos="-0.9 -1.8 -0.38" type="box" size="0.02 0.02 0.38"'
+        ' rgba="0.1 0.1 0.1 1.0"/>\n'
+        '<geom name="leg_1" pos="-0.9 1.8 -0.38" type="box" size="0.02 0.02 0.38"'
+        ' rgba="0.1 0.1 0.1 1.0"/>\n'
+        '<geom name="leg_2" pos="0.9 -1.8 -0.38" type="box" size="0.02 0.02 0.38"'
+        ' rgba="0.1 0.1 0.1 1.0"/>\n'
+        '<geom name="leg_3" pos="0.9 1.8 -0.38" type="box" size="0.02 0.02 0.38"'
+        ' rgba="0.1 0.1 0.1 1.0"/>\n'
+        "</body>"
+    )
+
+    assert out_name_plate_geom == "NAME_plate"
+    assert out_name_net_geom == "NAME_net"
+    assert out_nb_bodies == 7
+
+
+def test_get_robot_xml_with_orientation() -> None:
+    model_name = "pam_mujoco_test_xml_template"
+
+    out_xml, out_joint, out_geom_racket, out_nb_bodies = m.get_robot_xml(
+        model_name,
+        "NAME",
+        [0, 1, 2],
+        Rotation.from_quat(np.array([0.0, 0.0, 0.4472136, 0.89442719])),
+        muscles=False,
+        robot_type=pam_mujoco.RobotType.PAMY2,
+    )
+
+    # strip whitespaces
+    out_xml = re.sub(" +", " ", out_xml.strip())
+
+    assert out_xml == (
+        '<body name="NAME" pos="0 1 2"'
+        ' quat="0.8944271889999159 0.0 0.0 0.4472135994999579">\n'
+        ' <include file="robot_body_NAME.xml"/>\n'
+        " </body>"
+    )
+    assert out_joint == "NAME_joint_base_rotation"
+    assert out_geom_racket == "NAME_racket"
+    assert out_nb_bodies == 25
+
+    assert pathlib.Path(
+        "/tmp/pam_mujoco_test_xml_template/robot_body_NAME.xml"
+    ).is_file()

--- a/tests/test_xml_templates.py
+++ b/tests/test_xml_templates.py
@@ -1,0 +1,14 @@
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+import pam_mujoco.xml_templates as m
+
+
+def test_mujoco_quaternion():
+    quat_xyzw = np.array([0.09365858, 0.18731716, 0.28097574, 0.93658581])
+    quat_wxyz = np.array([0.93658581, 0.09365858, 0.18731716, 0.28097574])
+
+    rot = Rotation.from_quat(quat_xyzw)
+    result = m._mujoco_quaternion(rot)
+
+    np.testing.assert_array_almost_equal(result, quat_wxyz)


### PR DESCRIPTION
## Description

Euler angles can be very confusing as there are many different conventions how to interpret the three angles (in MuJoCo this even depends on a compiler setting).  To avoid potential issues arising from this, write the orientations as quaternions in the XML files and use scipy's `Rotation` class to pass them around in our code.
This should make it all very explicit and avoid confusion for the user.

Other changes that are made as a part of this:
- Add more type hints.
- Add type stubs for scipy Rotation in a subdirectory `mypy_stubs`.  This is a bit annoying but while scipy already includes stub files, they are unfortunately not exported and thus cannot be used when checking our code.  Since mypy was of great help for checking if I adjusted the orientation format everywhere, I simply copied the relevant file from the scipy repository.
- Fix a few linter warnings regarding function default arguments.
- Add some tests for xml_templates.
- Avoid use of `locals()` to make the code easier to read and more linter friendly.

Note: **This is a breaking change!**  Other code that depends on this (e.g. in learning_table_tennis_from_scratch) needs to be adapted.

## How I Tested

By running unit tests and by running `hysr_start_robots`, to see if everything looks correct in the visualization.

## Do not merge before

- #41 

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
