### PR TITLE
chore: Exclude demos from mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.mypy]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/mypy_stubs"
 
+# Demos are currently outdated and cause lots of errors.  Exclude them until the issues
+# are fixed.
+exclude = "demos/"
+
 [[tool.mypy.overrides]]
 module = [
     "context",


### PR DESCRIPTION
## Description

Many demos are currently outdated/broken and cause lots of mypy  errors.
Exclude them from the check until the issues are fixed.  This means that mypy checks on pull requests should now generally succeed.


## How I Tested

`mypy .`