### PR TITLE
Aligning simulation and wallclock time in realtime mode without graphics

### DIFF
--- a/src/pam_mujoco.cpp
+++ b/src/pam_mujoco.cpp
@@ -1827,7 +1827,6 @@ void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)
                     mju_abs((d->time - simsync) - (tmstart - cpusync)) >
                         syncmisalign)
                 {
-                    std::cout << "out of sync" << std::endl;
                     // re-sync
                     cpusync = tmstart;
                     simsync = d->time;

--- a/src/pam_mujoco.cpp
+++ b/src/pam_mujoco.cpp
@@ -1801,11 +1801,12 @@ void render(GLFWwindow* window)
     }
 }
 
+// Get the current system time in seconds
 double get_current_time()
 {
     auto now = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::system_clock::now().time_since_epoch());
-    return static_cast<double>(now.count()) / 1e6;
+    return static_cast<double>(now.count()) * 1e-6;
 }
 
 void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)

--- a/src/pam_mujoco.cpp
+++ b/src/pam_mujoco.cpp
@@ -1801,8 +1801,10 @@ void render(GLFWwindow* window)
     }
 }
 
-double get_current_time() {
-    auto now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch());
+double get_current_time()
+{
+    auto now = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch());
     return static_cast<double>(now.count()) / 1e6;
 }
 
@@ -1844,7 +1846,8 @@ void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)
                 {
                     // step while simtime lags behind cputime, and within
                     // safefactor
-                    while ((d->time - simsync) < (get_current_time() - cpusync) &&
+                    while ((d->time - simsync) <
+                               (get_current_time() - cpusync) &&
                            (get_current_time() - tmstart) <
                                refreshfactor / vmode.refreshRate)
                     {

--- a/src/pam_mujoco.cpp
+++ b/src/pam_mujoco.cpp
@@ -1801,6 +1801,11 @@ void render(GLFWwindow* window)
     }
 }
 
+double get_current_time() {
+    auto now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch());
+    return static_cast<double>(now.count()) / 1e6;
+}
+
 void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)
 {
     // run only if model is present
@@ -1810,7 +1815,7 @@ void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)
         if (settings.run)
         {
             // record cpu time at start of iteration
-            double tmstart = glfwGetTime();
+            double tmstart = get_current_time();
 
             if (!accelerated_time)
             {
@@ -1819,6 +1824,7 @@ void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)
                     mju_abs((d->time - simsync) - (tmstart - cpusync)) >
                         syncmisalign)
                 {
+                    std::cout << "out of sync" << std::endl;
                     // re-sync
                     cpusync = tmstart;
                     simsync = d->time;
@@ -1838,8 +1844,8 @@ void do_simulate(bool accelerated_time, double& cpusync, mjtNum& simsync)
                 {
                     // step while simtime lags behind cputime, and within
                     // safefactor
-                    while ((d->time - simsync) < (glfwGetTime() - cpusync) &&
-                           (glfwGetTime() - tmstart) <
+                    while ((d->time - simsync) < (get_current_time() - cpusync) &&
+                           (get_current_time() - tmstart) <
                                refreshfactor / vmode.refreshRate)
                     {
                         // clear old perturbations, apply new
@@ -2096,7 +2102,7 @@ int main(int argc, const char** argv)
     // episode id (if it turns out the client deals with episodes)
     shared_memory::set<long int>(mujoco_id, "episode", -1);
 
-    // indicating potiential clients that it is not running yet
+    // indicating potential clients that it is not running yet
     shared_memory::set<bool>(mujoco_id, "running", false);
 
     pam_mujoco::MujocoConfig config;

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -12,9 +12,7 @@ import pam_mujoco
 def test_realtime_step_duration():
     mujoco_id = "simulation"
     process = subprocess.Popen(
-        f"launch_pam_mujoco {mujoco_id}",
-        shell=True,
-        preexec_fn=os.setsid
+        f"launch_pam_mujoco {mujoco_id}", shell=True, preexec_fn=os.setsid
     )
     time.sleep(1)
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,52 @@
+import subprocess
+import time
+
+import numpy as np
+import pytest
+
+import pam_mujoco
+
+
+def test_realtime_step_duration():
+    mujoco_id = "simulation"
+    process = subprocess.Popen(f"launch_pam_mujoco {mujoco_id}", shell=True)
+    time.sleep(1)
+
+    try:
+        robot_segment_id = "robot"
+        time_step = 0.002
+        robot = pam_mujoco.MujocoRobot(
+            pam_mujoco.RobotType.PAMY2,
+            robot_segment_id,
+            control=pam_mujoco.MujocoRobot.PRESSURE_CONTROL,
+        )
+        handle = pam_mujoco.MujocoHandle(
+            mujoco_id,
+            robot1=robot,
+            time_step=time_step,
+            graphics=False,
+            accelerated_time=False,
+            burst_mode=False,
+        )
+
+        frontend = handle.frontends[robot_segment_id]
+
+        curr_time_sim = frontend.latest().get_time_stamp()
+        last_time_sim = curr_time_sim
+        last_wall_time = time.time()
+        steps_sim = []
+        durations_wall = []
+        for _ in range(100):
+            while curr_time_sim == last_time_sim:
+                curr_time_sim = frontend.latest().get_time_stamp()
+            curr_wall_time = time.time()
+            steps_sim.append(curr_time_sim - last_time_sim)
+            durations_wall.append(curr_wall_time - last_wall_time)
+            last_time_sim = curr_time_sim
+            last_wall_time = time.time()
+        assert np.all(np.array(steps_sim) == int(time_step * 1e9))
+        # There is some fluctuation in the timings of individual steps,
+        # but the average should match the timestep well.
+        assert np.mean(durations_wall) == pytest.approx(time_step, abs=5e-5)
+    finally:
+        process.kill()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2,14 +2,20 @@ import subprocess
 import time
 
 import numpy as np
+import os
 import pytest
+import signal
 
 import pam_mujoco
 
 
 def test_realtime_step_duration():
     mujoco_id = "simulation"
-    process = subprocess.Popen(f"launch_pam_mujoco {mujoco_id}", shell=True)
+    process = subprocess.Popen(
+        f"launch_pam_mujoco {mujoco_id}",
+        shell=True,
+        preexec_fn=os.setsid
+    )
     time.sleep(1)
 
     try:
@@ -49,4 +55,5 @@ def test_realtime_step_duration():
         # but the average should match the timestep well.
         assert np.mean(durations_wall) == pytest.approx(time_step, abs=5e-5)
     finally:
-        process.kill()
+        # Clean up the launch_pam_mujoco process
+        os.killpg(process.pid, signal.SIGINT)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Replaces `glfwGetTime()` with `std::chrono::system_clock::now()` since the glfw timestamps are 0 if the simulation is started without graphics. This ensures that the wallclock time for a step (roughly) aligns with the simulation time, independent of whether the simulation was started with or without graphics.

The following script shows that there are still some significant fluctuations in the wallclock times for individual steps, but I doubt that these are related to the changes in this PR. The average wallclock time per step matches the expected time quite well.
```python
import numpy as np
import pam_mujoco
import time

if __name__ == "__main__":
    mujoco_id = "simulation"
    robot_segment_id = "robot"
    robot = pam_mujoco.MujocoRobot(
        pam_mujoco.RobotType.PAMY2,
        robot_segment_id,
        control=pam_mujoco.MujocoRobot.PRESSURE_CONTROL,
    )
    handle = pam_mujoco.MujocoHandle(
        mujoco_id,
        robot1=robot,
        graphics=False,
        accelerated_time=False,
        burst_mode=False,
    )

    frontend = handle.frontends[robot_segment_id]

    curr_timestamp = frontend.latest().get_time_stamp()
    last_timestamp = curr_timestamp
    last_python_time = time.time()
    durations = []
    for _ in range(100):
        while curr_timestamp == last_timestamp:
            curr_timestamp = frontend.latest().get_time_stamp()
        curr_python_time = time.time()
        print(f"o80 duration: {(curr_timestamp - last_timestamp) * 1e-9}, python duration: {curr_python_time - last_python_time:.6f}")
        durations.append(curr_python_time - last_python_time)
        last_timestamp = curr_timestamp
        last_python_time = time.time()
    print(f"Average: {np.mean(durations)}")
```
Output:
```
[...]
o80 duration: 0.002, python duration: 0.002233
o80 duration: 0.002, python duration: 0.002256
o80 duration: 0.002, python duration: 0.002202
o80 duration: 0.002, python duration: 0.001332
o80 duration: 0.002, python duration: 0.002238
o80 duration: 0.002, python duration: 0.002212
o80 duration: 0.002, python duration: 0.002450
o80 duration: 0.002, python duration: 0.001165
o80 duration: 0.002, python duration: 0.002243
o80 duration: 0.002, python duration: 0.002222
Average: 0.0019804525375366213
```

## How I Tested

[//]: # "Explain how you tested your changes"

See [this test](https://github.com/intelligent-soft-robots/pam_mujoco/blob/59ea172cf39e82a938b0a5bff64cd84a2a42890f/tests/test_simulation.py#L12-L59).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
